### PR TITLE
Composite children

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -46,7 +46,7 @@ describe('Components', () => {
     });
   });
 
-  test.skip('It renders composite child elements', done => {
+  test('It renders composite child elements', done => {
     const RedMarker = ({ color, ...props }) => (
       <Marker color="red" {...props} />
     );

--- a/package.json
+++ b/package.json
@@ -9,12 +9,9 @@
     "url": "git@github.com:bondz/react-static-google-map.git"
   },
   "author": "Akinmade Bond <bond@max.ng>",
+  "typings": "./typings/index.d.ts",
   "license": "MIT",
-  "keywords": [
-    "react",
-    "static google map",
-    "google map"
-  ],
+  "keywords": ["react", "static google map", "google map"],
   "dependencies": {
     "invariant": "^2.2.2",
     "react": ">=0.14.x",
@@ -47,12 +44,8 @@
     "test": "jest",
     "prepublish": "yarn build"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "jest": {
-    "setupFiles": [
-      "raf/polyfill"
-    ]
+    "setupFiles": ["raf/polyfill"]
   }
 }

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -9,6 +9,12 @@ import MarkerGroupStrategy from '../strategies/markergroup';
 import PathGroupStrategy from '../strategies/pathgroup';
 import DirectionStrategy from '../strategies/direction/index';
 import MapStrategy from '../strategies/map';
+import {
+  isStatelessComponent,
+  renderStatelessComponent,
+  isClassComponent,
+  renderClassComponent,
+} from '../strategies/utils';
 
 class StaticGoogleMap extends Component {
   static propTypes = {
@@ -52,19 +58,39 @@ class StaticGoogleMap extends Component {
   };
 
   buildParts(children, props) {
-    return React.Children.map(children, Child => {
-      switch (Child.type.name) {
+    return React.Children.map(children, child => {
+      if (!React.isValidElement(child)) {
+        return null;
+      }
+
+      switch (child.type.name) {
         case 'Marker':
-          return MarkerStrategy(Child, props);
+          return MarkerStrategy(child, props);
         case 'MarkerGroup':
-          return MarkerGroupStrategy(Child, props);
+          return MarkerGroupStrategy(child, props);
         case 'Path':
-          return PathStrategy(Child, props);
+          return PathStrategy(child, props);
         case 'PathGroup':
-          return PathGroupStrategy(Child, props);
+          return PathGroupStrategy(child, props);
         case 'Direction':
-          return DirectionStrategy(Child, props);
+          return DirectionStrategy(child, props);
         default:
+          const componentType = child.type;
+
+          if (isStatelessComponent(componentType)) {
+            return this.buildParts(
+              renderStatelessComponent(componentType, { ...child.props }),
+              props
+            );
+          }
+
+          if (isClassComponent(componentType)) {
+            return this.buildParts(
+              renderClassComponent(componentType, { ...child.props }),
+              props
+            );
+          }
+
           return null;
       }
     });

--- a/src/strategies/utils.js
+++ b/src/strategies/utils.js
@@ -24,3 +24,25 @@ export function locationBuilder(location) {
 
   return urlParts.join('%7C'); // |
 }
+
+export function isStatelessComponent(component) {
+  return (
+    !component.render && !(component.prototype && component.prototype.render)
+  );
+}
+
+export function isClassComponent(component) {
+  return Boolean(
+    component &&
+      component.prototype.isReactComponent &&
+      component.prototype.render
+  );
+}
+
+export function renderStatelessComponent(component, props) {
+  return component(props);
+}
+
+export function renderClassComponent(component, props) {
+  return new component(props).render();
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,13 +1,13 @@
 import { Component, ReactElement, ReactNode, ReactType } from 'react';
 
 declare class StaticGoogleMap extends Component<
-  StaticGoogleMap.GoogleMapImageProps
+  ReactStaticGoogleMap.GoogleMapImageProps
 > {}
-declare class Marker extends Component<StaticGoogleMap.Marker> {}
-declare class Path extends Component<StaticGoogleMap.Path> {}
-declare class Direction extends Component<StaticGoogleMap.Direction> {}
+declare class Marker extends Component<ReactStaticGoogleMap.Marker> {}
+declare class Path extends Component<ReactStaticGoogleMap.Path> {}
+declare class Direction extends Component<ReactStaticGoogleMap.Direction> {}
 
-declare namespace StaticGoogleMap {
+declare namespace ReactStaticGoogleMap {
   interface GoogleMapImageProps {
     /**
      * Any element that accepts a 'src' attribute

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,11 +1,4 @@
-import { Component, ReactElement, ReactNode, ReactType } from 'react';
-
-declare class StaticGoogleMap extends Component<
-  ReactStaticGoogleMap.GoogleMapImageProps
-> {}
-declare class Marker extends Component<ReactStaticGoogleMap.Marker> {}
-declare class Path extends Component<ReactStaticGoogleMap.Path> {}
-declare class Direction extends Component<ReactStaticGoogleMap.Direction> {}
+import { Component, StatelessComponent } from 'react';
 
 declare namespace ReactStaticGoogleMap {
   interface GoogleMapImageProps {
@@ -170,6 +163,12 @@ declare namespace ReactStaticGoogleMap {
     location: locationType;
   }
 
+  declare const MarkerGroupComponent: StatelessComponent<MarkerGroup>;
+
+  interface MarkerComponent extends StatelessComponent<Marker> {
+    Group: typeof MarkerGroupComponent;
+  }
+
   interface PathGroup {
     weight?: string | number;
     color?:
@@ -191,6 +190,12 @@ declare namespace ReactStaticGoogleMap {
 
   interface Path extends PathGroup {
     points: locationType;
+  }
+
+  declare const PathGroupComponent: StatelessComponent<PathGroup>;
+
+  interface PathComponent extends StatelessComponent<Path> {
+    Group: typeof PathGroupComponent;
   }
 
   interface Direction extends PathGroup {
@@ -220,4 +225,14 @@ declare namespace ReactStaticGoogleMap {
     [index: string]: any;
   }
 }
+
+declare class StaticGoogleMap extends Component<
+  ReactStaticGoogleMap.GoogleMapImageProps,
+  object
+> {}
+
+declare const Marker: ReactStaticGoogleMap.MarkerComponent;
+declare const Path: ReactStaticGoogleMap.PathComponent;
+declare const Direction: StatelessComponent<ReactStaticGoogleMap.Direction>;
+
 export { StaticGoogleMap, Marker, Path, Direction };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,211 +1,223 @@
-interface GoogleMapImageProps {
-  /**
+import { Component, ReactElement, ReactNode, ReactType } from 'react';
+
+declare class StaticGoogleMap extends Component<
+  StaticGoogleMap.GoogleMapImageProps
+> {}
+declare class Marker extends Component<StaticGoogleMap.Marker> {}
+declare class Path extends Component<StaticGoogleMap.Path> {}
+declare class Direction extends Component<StaticGoogleMap.Direction> {}
+
+declare namespace StaticGoogleMap {
+  interface GoogleMapImageProps {
+    /**
      * Any element that accepts a 'src' attribute
      *
      * @type {*}
      * @memberof GoogleMapImageProps
      * @default img
      */
-  as?: any;
+    as?: any;
 
-  /**
+    /**
      * A callback function that is called with the generated URL
      *
      * @memberof GoogleMapImageProps
      */
-  onGenerate?: (url: string) => void;
+    onGenerate?: (url: string) => void;
 
-  /**
+    /**
      * The dimensions of the image in pixels
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  size: string;
+    size: string;
 
-  /**
+    /**
      * The scale of the image
      *
      * @type {('1' | '2' | '4' | 1 | 2 | 4)}
      * @memberof GoogleMapImageProps
      * @default 1
      */
-  scale?: '1' | '2' | '4' | 1 | 2 | 4;
+    scale?: '1' | '2' | '4' | 1 | 2 | 4;
 
-  /**
+    /**
      * The format of the image to return
      *
      * @type {('png' | 'png8' | 'png32' | 'gif' | 'jpg' | 'jpg-baseline')}
      * @memberof GoogleMapImageProps
      * @default png
      */
-  format?: 'png' | 'png8' | 'png32' | 'gif' | 'jpg' | 'jpg-baseline';
+    format?: 'png' | 'png8' | 'png32' | 'gif' | 'jpg' | 'jpg-baseline';
 
-  /**
+    /**
      * The type of map to return
      *
      * @type {('roadmap' | 'satellite' | 'terrain' | 'hybrid')}
      * @memberof GoogleMapImageProps
      * @default roadmap
      */
-  maptype?: 'roadmap' | 'satellite' | 'terrain' | 'hybrid';
+    maptype?: 'roadmap' | 'satellite' | 'terrain' | 'hybrid';
 
-  /**
+    /**
      * The language to use for the text on the map
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      * @default en
      */
-  language?: string;
+    language?: string;
 
-  region?: string;
+    region?: string;
 
-  /**
+    /**
      * Specified the center of the image
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  center?: string;
+    center?: string;
 
-  /**
+    /**
      * DSPecifies the zoom level of the image
      *
      * @type {(string | number)}
      * @memberof GoogleMapImageProps
      * @default 0
      */
-  zoom?: string | number;
+    zoom?: string | number;
 
-  visible?: string;
+    visible?: string;
 
-  style?: string;
+    style?: string;
 
-  /**
+    /**
      * Paths to show on the map
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  path?: string;
+    path?: string;
 
-  /**
+    /**
      * The ClientID for premium users
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  client?: string;
+    client?: string;
 
-  /**
+    /**
      * Your API key
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  apiKey?: string;
+    apiKey?: string;
 
-  /**
+    /**
      * Digital signature
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  signature?: string;
+    signature?: string;
 
-  /**
+    /**
      * Channel for premium users
      *
      * @type {string}
      * @memberof GoogleMapImageProps
      */
-  channel?: string;
-}
+    channel?: string;
+  }
 
-type locationType =
-  | string
-  | number
-  | { lat: string | number; lng: string | number }
-  | Array<string | number | { lat: string | number; lng: string | number }>;
-
-interface MarkerGroup {
-  size: 'tiny' | 'mid' | 'small' | 'normal';
-  color:
-    | 'black'
-    | 'brown'
-    | 'green'
-    | 'purple'
-    | 'yellow'
-    | 'blue'
-    | 'gray'
-    | 'orange'
-    | 'red'
-    | 'white'
-    | number;
-  iconURL: string;
-  label: string;
-  anchor:
-    | 'left'
-    | 'right'
-    | 'center'
-    | 'topleft'
-    | 'topright'
-    | 'bottomleft'
-    | 'bottomright'
-    | string;
-}
-
-interface Marker extends MarkerGroup {
-  location: locationType;
-}
-
-interface PathGroup {
-  weight?: string | number;
-  color?:
-    | 'black'
-    | 'brown'
-    | 'green'
-    | 'purple'
-    | 'yellow'
-    | 'blue'
-    | 'gray'
-    | 'orange'
-    | 'red'
-    | 'white'
+  type locationType =
     | string
-    | number;
-  fillcolor?: string;
-  geodesic?: boolean;
-}
+    | number
+    | { lat: string | number; lng: string | number }
+    | Array<string | number | { lat: string | number; lng: string | number }>;
 
-interface Path extends PathGroup {
-  points: locationType;
-}
+  interface MarkerGroup {
+    size: 'tiny' | 'mid' | 'small' | 'normal';
+    color:
+      | 'black'
+      | 'brown'
+      | 'green'
+      | 'purple'
+      | 'yellow'
+      | 'blue'
+      | 'gray'
+      | 'orange'
+      | 'red'
+      | 'white'
+      | number;
+    iconURL: string;
+    label: string;
+    anchor:
+      | 'left'
+      | 'right'
+      | 'center'
+      | 'topleft'
+      | 'topright'
+      | 'bottomleft'
+      | 'bottomright'
+      | string;
+  }
 
-interface Direction extends PathGroup {
-  origin: string | { lat: string | number; lng: string | number };
-  destination: string | { lat: string | number; lng: string | number };
-  apiKey: string;
-  waypoints: any;
-  avoid: 'tolls' | 'highways' | 'ferries' | 'indoor';
-  travelMode: 'driving' | 'walking' | 'bicycling' | 'transit';
-  transitMode: 'bus' | 'subway' | 'train' | 'tram' | 'rail';
-  transitRoutingPreference: 'less_walking' | 'fewer_transfers';
-  requestStrategy: 'fetch' | 'native' | RequestStrategy;
-}
+  interface Marker extends MarkerGroup {
+    location: locationType;
+  }
 
-type RequestStrategy = (data: RequestStrategyOptions) => Promise<string>;
+  interface PathGroup {
+    weight?: string | number;
+    color?:
+      | 'black'
+      | 'brown'
+      | 'green'
+      | 'purple'
+      | 'yellow'
+      | 'blue'
+      | 'gray'
+      | 'orange'
+      | 'red'
+      | 'white'
+      | string
+      | number;
+    fillcolor?: string;
+    geodesic?: boolean;
+  }
 
-interface RequestStrategyOptions {
-  baseURL: string;
-  key: string;
-  origin: string | { lat: string | number; lng: string | number };
-  destination: string | { lat: string | number; lng: string | number };
-  waypoints?: any;
-  avoid?: 'tolls' | 'highways' | 'ferries' | 'indoor';
-  mode: 'driving' | 'walking' | 'bicycling' | 'transit';
-  transitMode?: 'bus' | 'subway' | 'train' | 'tram' | 'rail';
-  transitRoutingPreference?: 'less_walking' | 'fewer_transfers';
-  [index: string]: any;
+  interface Path extends PathGroup {
+    points: locationType;
+  }
+
+  interface Direction extends PathGroup {
+    origin: string | { lat: string | number; lng: string | number };
+    destination: string | { lat: string | number; lng: string | number };
+    apiKey: string;
+    waypoints: any;
+    avoid: 'tolls' | 'highways' | 'ferries' | 'indoor';
+    travelMode: 'driving' | 'walking' | 'bicycling' | 'transit';
+    transitMode: 'bus' | 'subway' | 'train' | 'tram' | 'rail';
+    transitRoutingPreference: 'less_walking' | 'fewer_transfers';
+    requestStrategy: 'fetch' | 'native' | RequestStrategy;
+  }
+
+  type RequestStrategy = (data: RequestStrategyOptions) => Promise<string>;
+
+  interface RequestStrategyOptions {
+    baseURL: string;
+    key: string;
+    origin: string | { lat: string | number; lng: string | number };
+    destination: string | { lat: string | number; lng: string | number };
+    waypoints?: any;
+    avoid?: 'tolls' | 'highways' | 'ferries' | 'indoor';
+    mode: 'driving' | 'walking' | 'bicycling' | 'transit';
+    transitMode?: 'bus' | 'subway' | 'train' | 'tram' | 'rail';
+    transitRoutingPreference?: 'less_walking' | 'fewer_transfers';
+    [index: string]: any;
+  }
 }
+export { StaticGoogleMap, Marker, Path, Direction };


### PR DESCRIPTION
This enables processing composite children components. So, things like 

```jsx
const GreenMarker = ({ color, ...props }) => (
  <Marker color="green" {...props} />
);

class BlueMarker extends Component {
  render() {
    const { color, ...props } = this.props;

    return <Marker color="blue" {...props} />;
  }
}
```

Now work when passed as children.