### PR TITLE
Remove invalid nested `declare` keywords from typings.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -163,7 +163,7 @@ declare namespace ReactStaticGoogleMap {
     location: locationType;
   }
 
-  declare const MarkerGroupComponent: StatelessComponent<MarkerGroup>;
+  const MarkerGroupComponent: StatelessComponent<MarkerGroup>;
 
   interface MarkerComponent extends StatelessComponent<Marker> {
     Group: typeof MarkerGroupComponent;
@@ -192,7 +192,7 @@ declare namespace ReactStaticGoogleMap {
     points: locationType;
   }
 
-  declare const PathGroupComponent: StatelessComponent<PathGroup>;
+  const PathGroupComponent: StatelessComponent<PathGroup>;
 
   interface PathComponent extends StatelessComponent<Path> {
     Group: typeof PathGroupComponent;


### PR DESCRIPTION
Reported at https://stackoverflow.com/q/52079900 .