### PR TITLE
Memoize the directionStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ It takes the following props as well as props from [Path Component](#path-compon
 
 - `origin` -  (required) specifies the start location from which to calculate directions. This value may be specified as a String (for example, "Chicago, IL"), as a LatLng value
 - `destination` - (required) specifies the end location to which to calculate directions. The options are the same as for the origin field described above.
-- `traveMode` - (optional) specifies what mode of transport to use when calculating directions. Valid values are `driving (Default), bicycling, transit, and WALKING`
+- `travelMode` - (optional) specifies what mode of transport to use when calculating directions. Valid values are `driving (Default), bicycling, transit, and WALKING`
 - `requestStrategy` - (optional) A function that takes origin, destination, and travelMode as parameters and returns a string promise of the encoded polyline path to draw on the map.
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ It takes the following props as well as props from [Path Component](#path-compon
 - `travelMode` - (optional) specifies what mode of transport to use when calculating directions. Valid values are `driving (Default), bicycling, transit, and WALKING`
 - `requestStrategy` - (optional) A function that takes origin, destination, and travelMode as parameters and returns a string promise of the encoded polyline path to draw on the map.
 
+Also see the `cache` and `onCacheUpdate` props on the `StaticGoogleMap` component.
+
 ### Examples
 
 ```jsx
@@ -260,6 +262,8 @@ It takes the following props
 - `signature`: (recommended) is a digital signature used to verify that any site generating requests using your API key is authorized to do so.
 - `client`: (optional) By using your client ID (instead of an API key) to authenticate requests, you can: Add the channel parameter to requests so you can view more detailed usage reports.
 - `channel`: (optional) used to provide additional reporting detail, by grouping different channels separately in your reports. Refer to the [Premium Plan Reporting Overview](https://developers.google.com/maps/premium/reports/) for more information.
+- `cache`: (optional, default: true) Only used when rendering a `Direction` component. Because the `Direction` component is async and will attempt to fetch directions on each render, setting this prop to `true` will keep an internal cache of requests. This saves calls to the directions service as well as prevents the component from flashing as it fetches new directions. You can also initialize the cache by passing it an object.
+- `onCacheUpate`: (optional) Only used when rendering a `Direction` component. This function will be called everytime a new entry is added to the internal cache. It can be used to save the cache to localStorage, for example. This is helpful to intilialize the `cache` prop from storage.
 
 ### URL Size Restriction
 

--- a/src/components/Direction.js
+++ b/src/components/Direction.js
@@ -7,6 +7,8 @@ const propTypes = {
   destination: PropTypes.string.isRequired,
   apiKey: PropTypes.string,
   waypoints: PropTypes.any,
+  // cache: PropTypes.object,
+  // onCacheUpdate: PropTypes.func,
 
   avoid: PropTypes.string,
   travelMode: PropTypes.oneOf(['driving', 'walking', 'bicycling', 'transit']),

--- a/src/components/Direction.js
+++ b/src/components/Direction.js
@@ -7,8 +7,6 @@ const propTypes = {
   destination: PropTypes.string.isRequired,
   apiKey: PropTypes.string,
   waypoints: PropTypes.any,
-  // cache: PropTypes.object,
-  // onCacheUpdate: PropTypes.func,
 
   avoid: PropTypes.string,
   travelMode: PropTypes.oneOf(['driving', 'walking', 'bicycling', 'transit']),

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -24,8 +24,6 @@ class StaticGoogleMap extends Component {
     as: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     onGenerate: PropTypes.func,
     rootURL: PropTypes.string,
-    cache: PropTypes.oneOfType([PropTypes.object, PropTypes.boolean]),
-    onCacheUpdate: PropTypes.func,
 
     size: PropTypes.string.isRequired,
     scale: PropTypes.oneOf([1, 2, 4, '1', '2', '4']),
@@ -51,6 +49,9 @@ class StaticGoogleMap extends Component {
     apiKey: PropTypes.string,
     signature: PropTypes.string,
     channel: PropTypes.string,
+
+    cache: PropTypes.oneOfType([PropTypes.object, PropTypes.boolean]),
+    onCacheUpdate: PropTypes.func,
   };
 
   static defaultProps = {

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -7,7 +7,7 @@ import MarkerStrategy from '../strategies/marker';
 import PathStrategy from '../strategies/path';
 import MarkerGroupStrategy from '../strategies/markergroup';
 import PathGroupStrategy from '../strategies/pathgroup';
-import DirectionStrategy from '../strategies/direction/index';
+import DirectionStrategy, { memoizeDirectionStrategy } from '../strategies/direction/index';
 import MapStrategy from '../strategies/map';
 import Marker from './Marker';
 import Path from './Path';
@@ -24,6 +24,8 @@ class StaticGoogleMap extends Component {
     as: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     onGenerate: PropTypes.func,
     rootURL: PropTypes.string,
+    initialCache: PropTypes.object,
+    onCacheUpdate: PropTypes.func,
 
     size: PropTypes.string.isRequired,
     scale: PropTypes.oneOf([1, 2, 4, '1', '2', '4']),
@@ -60,6 +62,11 @@ class StaticGoogleMap extends Component {
     maptype: 'roadmap',
   };
 
+  DirectionStrategy = memoizeDirectionStrategy(
+    DirectionStrategy,
+    { ...this.props.initialCache }
+  );
+
   buildParts(children, props) {
     return React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
@@ -76,7 +83,7 @@ class StaticGoogleMap extends Component {
         case Path.Group:
           return PathGroupStrategy(child, props);
         case Direction:
-          return DirectionStrategy(child, props);
+          return this.DirectionStrategy(child, props);
         default:
           const componentType = child.type;
 

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -24,7 +24,7 @@ class StaticGoogleMap extends Component {
     as: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     onGenerate: PropTypes.func,
     rootURL: PropTypes.string,
-    initialCache: PropTypes.object,
+    cache: PropTypes.oneOfType([PropTypes.object, PropTypes.boolean]),
     onCacheUpdate: PropTypes.func,
 
     size: PropTypes.string.isRequired,
@@ -60,11 +60,12 @@ class StaticGoogleMap extends Component {
     rootURL: 'https://maps.googleapis.com/maps/api/staticmap',
     apiKey: '',
     maptype: 'roadmap',
+    cache: true
   };
 
-  DirectionStrategy = memoizeDirectionStrategy(
+  MemoizedDirectionStrategy = memoizeDirectionStrategy(
     DirectionStrategy,
-    { ...this.props.initialCache }
+    { ...this.props.cache }
   );
 
   buildParts(children, props) {
@@ -83,7 +84,10 @@ class StaticGoogleMap extends Component {
         case Path.Group:
           return PathGroupStrategy(child, props);
         case Direction:
-          return this.DirectionStrategy(child, props);
+          if (props.cache) {
+            return this.MemoizedDirectionStrategy(child, props);
+          }
+          return DirectionStrategy(child, props)
         default:
           const componentType = child.type;
 
@@ -124,7 +128,7 @@ class StaticGoogleMap extends Component {
       language,
       signature,
       apiKey,
-      initialCache,
+      cache,
       onCacheUpdate,
       ...componentProps
     } = props;

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -124,6 +124,8 @@ class StaticGoogleMap extends Component {
       language,
       signature,
       apiKey,
+      initialCache,
+      onCacheUpdate,
       ...componentProps
     } = props;
 

--- a/src/strategies/direction/index.js
+++ b/src/strategies/direction/index.js
@@ -89,12 +89,12 @@ const directionStrategy = ({ props, type: { defaultProps } }, parentProps) => {
     }
   }
 
-  return pathPromise.then(path => {
-    return PathStrategy({
+  return pathPromise.then(path =>
+    PathStrategy({
       props: { weight, color, fillcolor, geodesic, points: `enc:${path}` },
       type: { defaultProps },
     })
-  });
+  );
 };
 
 export default directionStrategy;

--- a/src/strategies/direction/index.js
+++ b/src/strategies/direction/index.js
@@ -4,7 +4,44 @@ import PathStrategy from '../path';
 import NativeStrategy from './nativeStrategy';
 import FetchStrategy from './fetchStrategy';
 
-const directionStrategy = ({ props, type: { defaultProps } }, parentProps) => {
+let googleCalls = 0;
+
+const memoize = (func) => {
+  const cache = {};
+  return function(){
+    console.log(...arguments)
+    const key = JSON.stringify(arguments[0].props);
+    console.log({ key })
+    if (cache[key]){
+      console.log('returned from cache')
+      console.log(typeof cache[key])
+      console.log(cache[key])
+      return cache[key];
+    }
+    else{
+      const val = func.apply(null, arguments).then(path => {
+        // When this finally resolves, set the value of the cache to
+        // the string path result. Subsequent renders will return a string
+        // and use the base compnent instead of the Async component
+        cache[key] = path;
+        console.log('After Resolve: ', typeof cache[key])
+        console.log('After Resolve: ', cache[key])
+      });
+      // Return the pending promise immedietly and the StaticGoogleMap
+      // usage of the Async component will eventually handle it because
+      // this funciton returned a Promise. This piece of the code prevents
+      // multiple calls to google on each render, but does not solve the
+      // "flash" of the Async component.
+      cache[key] = val;
+      console.log('Before Resolve: ', typeof cache[key])
+      console.log('Before Resolve: ', cache[key])
+      console.log('cache set')
+      return val;
+    }
+  }
+}
+
+const directionStrategy = memoize(({ props, type: { defaultProps } }, parentProps) => {
   const {
     baseURL,
     requestStrategy,
@@ -16,6 +53,8 @@ const directionStrategy = ({ props, type: { defaultProps } }, parentProps) => {
     travelMode,
     transitMode,
     transitRoutingPreference,
+    // cache,
+    // onCacheUpdate,
 
     weight,
     color,
@@ -44,6 +83,20 @@ const directionStrategy = ({ props, type: { defaultProps } }, parentProps) => {
     ...rest,
   };
 
+  // let cacheKey;
+
+  // if (cache) {
+  //   cacheKey = JSON.stringify(data);
+  //   const path = cache[cacheKey];
+  //   if (path) {
+  //     console.log('returned from cache')
+  //     return PathStrategy({
+  //       props: { weight, color, fillcolor, geodesic, points: `enc:${path}` },
+  //       type: { defaultProps },
+  //     });
+  //   }
+  // }
+
   let pathPromise;
 
   if (typeof requestStrategy !== 'string') {
@@ -61,12 +114,21 @@ const directionStrategy = ({ props, type: { defaultProps } }, parentProps) => {
     }
   }
 
-  return pathPromise.then(path =>
-    PathStrategy({
+  return pathPromise.then(path => {
+    googleCalls = googleCalls + 1;
+    console.log(googleCalls)
+    // if (cache && cacheKey) {
+    //   console.log('cache set')
+    //   cache[cacheKey] = path;
+    //   if (onCacheUpdate) {
+    //     onCacheUpdate({ ...cache })
+    //   }
+    // }
+    return PathStrategy({
       props: { weight, color, fillcolor, geodesic, points: `enc:${path}` },
       type: { defaultProps },
     })
-  );
-};
+  });
+});
 
 export default directionStrategy;

--- a/src/strategies/direction/index.js
+++ b/src/strategies/direction/index.js
@@ -5,10 +5,8 @@ import NativeStrategy from './nativeStrategy';
 import FetchStrategy from './fetchStrategy';
 
 export const memoizeDirectionStrategy = (directionStrategy, cache = {}) => {
-  return function() {
-    const componentProps = arguments[0].props;
-    const parentProps = arguments[1];
-    const key = JSON.stringify(componentProps);
+  return function({ props }, parentProps) {
+    const key = JSON.stringify(props);
     if (cache[key]){
       return cache[key];
     } else {

--- a/src/strategies/direction/index.js
+++ b/src/strategies/direction/index.js
@@ -25,7 +25,7 @@ export const memoizeDirectionStrategy = (directionStrategy, cache = {}) => {
       });
       // Return the pending promise immedietly and the StaticGoogleMap
       // usage of the Async component will eventually handle it because
-      // this funciton returned a Promise. This piece of the code prevents
+      // this function returned a Promise. This piece of the code prevents
       // multiple calls to google on each render, but does not solve the
       // "flash" of the Async component.
       cache[key] = promise;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -124,7 +124,30 @@ declare namespace ReactStaticGoogleMap {
      * @memberof GoogleMapImageProps
      */
     channel?: string;
+
+    /**
+     * An object where each key is the JSON.stringify(props)
+     * of the Direction component and each value is the
+     * generated path of those props for the internal cache
+     * to be initiated with. Can also be set to boolean if
+     * no initial cache is given
+     *
+     * @type {boolean | object}
+     * @memberof GoogleMapImageProps
+     * @default true
+     */
+    cache?: boolean | cacheType;
+
+    /**
+     * A callback function that is called when a new entry
+     * is added to the internal Direction cache
+     *
+     * @memberof GoogleMapImageProps
+     */
+    onCacheUpdate?: (cache: cacheType) => void;
   }
+
+  type cacheType = boolean | { [stringProps: string]: string }
 
   type locationType =
     | string


### PR DESCRIPTION
See issue: https://github.com/bondz/react-static-google-map/issues/42

This is a first pass at optimizing the `Direction` component and is very much a WIP.

This ended up being quite a bit tricker than I initially suspected it would. There are really two main problems.
1 - The component calls google on EVERY render, wasting google calls (and $$$).
2 - The component "flashes" as the `Async` component is resolving its promise.

My first crack at this is the mostly commented out code where I attempted a more traditional cache. This solved the flash problem. This was a bit odd because of how the `Direction` component never actually mounts, and therefor I had trouble attaching something like `this.cache` to it and using it. This was probably my fault and lack of understanding of the children map. I tried making `Direction` a class and attaching `this.cache` in the constructor, then in the `React.Children.map` in `buildParts` that ultimately passes the `child` to `directionStrategy` I was never able to get at the `child.cache`.
But, the developer needed to pass down some "initial" cache, which the component updated...but then should not cause a re-render (by setting some outside state that updates the cache) but still needed to maintain its pointer...very side effecty. I also thought about having the `StaticGoogleMap` component hold this "cache" and pass it down implicitly as a prop to the `Direction`, but that felt odd also but not too bad. That may be worth exploring more.

So then I realized that even with that internal cache, I was still hitting a race condition where renders above the `Direction` were causing Google calls before the first one had resolved and cached itself. In my case, there were 6-8 Google calls because I had a few `setStates` or prop changes above this `Direction` that happened before it had resolved its first render/call.

So my next attempt is the basic `memoize` function. I think it works pretty well and handles both problems. The memoized function returns a pending promise, until that promise has resolved in which it will then return the path. This means that the first render will kick off the Google call and cache the promise and the `Async` component will do its thing. Any Subsequent renders that happen before the promise has resolved will just return the same promise to the `Async` component, but any renders that happen after it has resolved will return a string path which will use the base component. Nice, thats what we want.

Overall the `memoize` is working great. I think we could probably clean it up (remove consoles and commented code), write some tests, and call it a win.

But there are some things I am not stoked about. 
1 - The cache can grow without bounds because it is a memoized function across all component instances. We need to store the cache somewhere, thats why I initially started to make `Direction` a class but then had trouble getting to it with how the components work together. 
2 - I think the developer should be able to hydrate the cache, from localStorage for example.

I will keep working on this, let me know any initial thoughts