### PR TITLE
Repository link not present on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "dist/react-static-google-map.umd.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:bondz/react-static-google-map.git"
+    "url": "https://github.com/bondz/react-static-google-map"
   },
   "sideEffects": false,
   "author": "Akinmade Bond <bond@max.ng>",


### PR DESCRIPTION
https://www.npmjs.com/package/react-static-google-map doesn't link to the github repository.

Trying to use a https url instead to resolve this.