### PR TITLE
Fix missing react-promise cjs.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "invariant": "^2.2.2",
     "react": ">=0.14.x",
-    "react-promise": "^2.0.0"
+    "react-promise": "2.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,9 +2735,10 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
-react-promise@^2.0.0:
+react-promise@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-promise/-/react-promise-2.0.0.tgz#089769abf2178c96b8932c7aae9b3ac878dd8c7c"
+  integrity sha512-Tzoleo9bA5rSFzAgWI31gyjTO+A7ByMRqVdhL34aEp7XqFRIi6G6Am+tBNSlFeW7+rPyhCVUbDEGj2BL49qWJA==
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
React-promise 2.1 no longer builds with commonjs hence no cjs.js fie
By Pinning the version to 2.0 fixes the "node_modules\react-static-google-map\node_modules\react-promise\dist\react-promise.cjs.js'. Please verify that the package.json has a valid "main" entry"

Fixes #71 #73 