### PR TITLE
move signature at the end of the URL

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -154,4 +154,21 @@ describe('Components', () => {
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
+
+  test('ULR should have signature as last part', async () => {
+    const title = 'A test title';
+    const signature = 'A test signature';
+    const alt = 'An alternate property';
+    const hasSignAtEnd = str => new RegExp(`.*&signature=${signature}$`).test(str);
+    render(
+      <StaticGoogleMap size="test" title={title} alt={alt} signature={signature}>
+        <Marker location="test" />
+      </StaticGoogleMap>
+    );
+
+    const node = screen.getByRole('img');
+    const src = node.getAttribute('src');
+
+    expect(hasSignAtEnd(src)).toBe(true);
+  });
 });

--- a/src/components/StaticGoogleMap.js
+++ b/src/components/StaticGoogleMap.js
@@ -141,7 +141,7 @@ class StaticGoogleMap extends Component {
     );
 
     const childrenUrlParts = this.buildParts(children, props) || [];
-    const mainUrlParts = MapStrategy(props);
+    const mainUrlParts = MapStrategy(props, undefined);
 
     /**
      * All the parts should return a string if a component that does not return a promise isn't used
@@ -150,7 +150,7 @@ class StaticGoogleMap extends Component {
      */
     if (!childrenUrlParts.some(part => typeof part === 'object')) {
       const childURL = childrenUrlParts.filter(part => part).join('&');
-      const url = `${mainUrlParts}&${childURL}`;
+      const url = MapStrategy(props, childURL);
 
       if (onGenerate) {
         onGenerate(url);

--- a/src/strategies/map.js
+++ b/src/strategies/map.js
@@ -1,6 +1,6 @@
 import { urlBuilder } from './utils';
 
-const MapStrategy = props => {
+const MapStrategy = (props, childURL) => {
   const {
     rootURL,
     size,
@@ -33,8 +33,9 @@ const MapStrategy = props => {
   urlParts.push(urlBuilder('channel', channel, '='));
   urlParts.push(urlBuilder('maptype', maptype, '='));
   urlParts.push(urlBuilder('language', language, '='));
-  urlParts.push(urlBuilder('signature', signature, '='));
   urlParts.push(urlBuilder('key', apiKey, '='));
+  if(childURL){ urlParts.push(childURL) }
+  urlParts.push(urlBuilder('signature', signature, '='));
 
   const parts = urlParts.filter(x => x).join('&');
 


### PR DESCRIPTION
Hi, as I understand from documentation (https://developers.google.com/maps/documentation/maps-static/get-api-key) signature should be the last part of the URL, making some tests it seems that if you put it in the middle of the URL it does not work.

With this version it seems to work (at last for my case), I make it early on a Monday morning so if there is something to improve let me know ^^"